### PR TITLE
Fix #55. Set imagePlaybackControlDialog, campTempMonitor pointers to null

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -965,7 +965,7 @@ void MainWindow::onRecordClick() {
         return;
     // GB added end
 
-    if(recordOn) {
+    if(recordOn && dataWriter) {
         // Deactivate recording
 
         dataWriter->close(); // TODO check if may terminate writing to early? because of the lag of the event queue in pupildetection
@@ -1106,6 +1106,7 @@ void MainWindow::onCameraDisconnectClick() {
         disconnect(imagePlaybackControlDialog, SIGNAL(onPlaybackSafelyStarted()), this, SLOT(onPlaybackSafelyStarted()));
         disconnect(imagePlaybackControlDialog, SIGNAL(onPlaybackSafelyPaused()), this, SLOT(onPlaybackSafelyPaused()));
         disconnect(imagePlaybackControlDialog, SIGNAL(onPlaybackSafelyStopped()), this, SLOT(onPlaybackSafelyStopped()));
+        imagePlaybackControlDialog = nullptr;
     }
     if(camTempMonitor) {
         if(recEventTracker)
@@ -1113,7 +1114,8 @@ void MainWindow::onCameraDisconnectClick() {
         
         camTempMonitor->setRunning(false);
         //camTempMonitor->thread()->deleteLater();
-        camTempMonitor->deleteLater(); 
+        camTempMonitor->deleteLater();
+        camTempMonitor = nullptr; 
     }
     trialWidget->setVisible(false);
 


### PR DESCRIPTION
Set imagePlaybackControlDialog, campTempMonitor pointers to null when not used.