### PR TITLE
Resolve #10.

### DIFF
--- a/PupilExt.qrc
+++ b/PupilExt.qrc
@@ -25,6 +25,7 @@
         <file>icons/Breeze/emblems/22/vcs-normal.svg</file>
         <file>icons/Breeze/actions/22/dialog-ok-apply.svg</file>
         <file>icons/Breeze/actions/22/dialog-cancel.svg</file>
+        <file>icons/Breeze/actions/22/gtk-convert.svg</file>
         <file>icons/Breeze/actions/22/im-user.svg</file>
         <file>icons/Breeze/actions/22/im-user-online.svg</file>
         <file>icons/Breeze/actions/22/edit-select-all.svg</file>

--- a/src/subwindows/singleCameraView.h
+++ b/src/subwindows/singleCameraView.h
@@ -51,7 +51,8 @@ private:
 
     QToolBar *toolBar;
     QAction *saveROI;
-    QAction *discardROI;
+    QAction *resetROI;
+    QAction *discardROISelection;
     QAction *plotMenuAct;
     QAction *displayDetailAct;
     QAction *plotCenterAct;
@@ -98,6 +99,9 @@ private:
     bool showAutoParamOverlay;
     
     void updateProcModeLabel();
+
+    QRectF tempROIRect1;
+    QRectF tempROIRect2;
     // GB added end
 
 public slots:
@@ -119,7 +123,8 @@ public slots:
     void onZoomMinusClick();
     void onSetROIClick(float roiSize);
     void onSaveROIClick();
-    void onDiscardROIClick();
+    void onResetROIClick();
+    void onDiscardROISelectionClick();
 
     void onDisplayPupilViewClick(bool value);
     void onPlotPupilCenterClick(bool value);

--- a/src/subwindows/stereoCameraView.h
+++ b/src/subwindows/stereoCameraView.h
@@ -56,7 +56,8 @@ private:
 
     QToolBar *toolBar;
     QAction *saveROI;
-    QAction *discardROI;
+    QAction *resetROI;
+    QAction *discardROISelection;
     QAction *plotMenuAct;
     QAction *displayDetailAct;
     QAction *plotCenterAct;
@@ -103,6 +104,9 @@ private:
     QAction *showAutoParamAct;
 
     bool showAutoParamOverlay;
+
+    QRectF tempROIs[4]; // 0 -> mainVideoView.ROI1Selection, 1 -> secondaryVideoView->ROI1Selection
+                        // 2 -> mainVideoView.ROI2Selection, 3 -> secondaryVideoView->ROI2Selection
     
     void updateProcModeLabel(); // GB added
     // GB added end
@@ -126,7 +130,8 @@ public slots:
     void onZoomMinusClick();
     void onSetROIClick(float roiSize);
     void onSaveROIClick();
-    void onDiscardROIClick();
+    void onResetROIClick();
+    void onDiscardROISelectionClick();
     void onPupilDetectionStart();
     void onPupilDetectionStop();
 

--- a/src/subwindows/videoView.cpp
+++ b/src/subwindows/videoView.cpp
@@ -706,7 +706,7 @@ bool VideoView::saveROI2Selection() {
 }
 
 // Discards the current ROI selection (GB: ROI nr 1 and 2), meaning no new ROI is set and the ROI selection is rest to a default size
-void VideoView::discardROISelection() {
+void VideoView::resetROISelection() {
 
     QRectF roiR;
 
@@ -719,7 +719,7 @@ void VideoView::discardROISelection() {
         roiR = QRectF( 0.35, 0.35, 0.3, 0.3 );
         roi1Selection->setBrush(selectionColorCorrect1);
         roi1Selection->setPos(0, 0);
-        qDebug() << "roi1Selection->setRect() via discardROISelection(): " << roiR; 
+        qDebug() << "roi1Selection->setRect() via resetROISelection(): " << roiR; 
         QRectF rect = roi1Selection->getRect();
         roi1SelectionRectLastR = roiR; 
         roi1Selection->setRect(QRect(roi1SelectionRectLastR.x()*imageSize.width,roi1SelectionRectLastR.y()*imageSize.height,roi1SelectionRectLastR.width()*imageSize.width,roi1SelectionRectLastR.height()*imageSize.height));
@@ -733,7 +733,7 @@ void VideoView::discardROISelection() {
         roiR = QRectF( 0.05, 0.35, 0.3, 0.3 );
         roi1Selection->setBrush(selectionColorCorrect1);
         roi1Selection->setPos(0, 0);
-        qDebug() << "roi1Selection->setRect() via discardROISelection(): " << roiR; 
+        qDebug() << "roi1Selection->setRect() via resetROISelection(): " << roiR; 
         
         roi1SelectionRectLastR = roiR; 
         roi1Selection->setRect(QRect(roi1SelectionRectLastR.x()*imageSize.width,roi1SelectionRectLastR.y()*imageSize.height,roi1SelectionRectLastR.width()*imageSize.width,roi1SelectionRectLastR.height()*imageSize.height));
@@ -746,7 +746,7 @@ void VideoView::discardROISelection() {
         roiR = QRectF( 0.65, 0.35, 0.3, 0.3 );
         roi2Selection->setBrush(selectionColorCorrect2);
         roi2Selection->setPos(0, 0);
-        qDebug() << "roi2Selection->setRect() via discardROISelection(): " << roiR; 
+        qDebug() << "roi2Selection->setRect() via resetROISelection(): " << roiR; 
         
         roi2SelectionRectLastR = roiR; 
         roi2Selection->setRect(QRect(roi2SelectionRectLastR.x()*imageSize.width,roi2SelectionRectLastR.y()*imageSize.height,roi2SelectionRectLastR.width()*imageSize.width,roi2SelectionRectLastR.height()*imageSize.height));
@@ -807,7 +807,7 @@ void VideoView::setROI1SelectionR(float roiSize) {
     else
         roi1SelectionRectLastR = QRectF(0.75-roiSize/2, 0.5-roiSize/2, roiSize, roiSize);
 
-    roi2Selection->setNormalizedRect(SupportFunctions::getRectDiscreteFromRational(QSizeF(imageSize.width, imageSize.height), roi2SelectionRectLastR));
+    roi1Selection->setNormalizedRect(SupportFunctions::getRectDiscreteFromRational(QSizeF(imageSize.width, imageSize.height), roi1SelectionRectLastR));
     
     qDebug() << "roi1Selection->setRect() via setROI1Selection(float roiSize) (RATIO): " << roi1SelectionRectLastR; 
 }
@@ -901,3 +901,10 @@ void VideoView::setROI2AllowedArea(int roiAllowedArea) {
     roi2AllowedArea = roiAllowedArea;
 }
 
+QRectF VideoView::getROI1SelectionR(){
+    return roi1SelectionRectLastR;
+}
+
+QRectF VideoView::getROI2SelectionR(){
+    return roi2SelectionRectLastR;
+}

--- a/src/subwindows/videoView.h
+++ b/src/subwindows/videoView.h
@@ -213,6 +213,9 @@ public slots:
     void setROI2SelectionR(float roiSize);
     void setROI2SelectionR(QRectF roi);
 
+    QRectF getROI1SelectionR();
+    QRectF getROI2SelectionR();
+
     void clearProcessedOverlayMemory();
 
     void setDoubleROI(bool state); 
@@ -234,7 +237,7 @@ public slots:
     bool saveROI1Selection();
     bool saveROI2Selection();
 
-    void discardROISelection();
+    void resetROISelection();
 
     void fitView();
     void showFullView();


### PR DESCRIPTION
Implemented ROI selection discard button and modified reset button, however, it might not be completely intuitive how these operate.
When the user clicks the "Custom", "30%", or "60%" buttons, the program stores the Pupil Detection ROI in temporary variables.
When the user clicks the discard button, it hides the ROI widgets, and restores the ROI to the previously saved values.
The reset button does not hide the ROI widgets, however reset the pupil detection ROI to a predefined value.

While I think the discard button works intuitively, the reset button should instead also load the previously stored values without hiding the ROI widgets.

I believe the original reset button functionality only made sense before loading of ROIs or setting sensible initial ROIs was implemented in #9.
