### PR TITLE
Resolved problems related to image or data recordings when existing data is found

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,8 @@ add_executable(PupilEXT main.cpp ${RESOURCE_ADDED} ${APP_ICON_RESOURCE_WINDOWS} 
         camImageRegionsWidget.h camImageRegionsWidget.cpp
         playbackSynchroniser.cpp
         playbackSynchroniser.h
+        subwindows/outputDataRuleDialog.h
+        subwindows/outputDataRuleDialog.cpp
 )
 
 # On linux with GCC and QT 5.15.2 setting standard here is recognized and is not overwritten by QT

--- a/src/PRGmainwindow.cpp
+++ b/src/PRGmainwindow.cpp
@@ -193,8 +193,8 @@ void MainWindow::PRGsetImageOutputFormat(QString format) {
         return;
 
     format.replace(".", "");
-    if(format=="tiff" || format =="jpg" || format=="bmp") {
-        applicationSettings->setValue("writerFormat", format);
+    if(format=="tiff" || format =="jpg" || format=="bmp" || format=="png") {
+        applicationSettings->setValue("imageWriterFormat", format);
     }
 }
 

--- a/src/dataWriter.cpp
+++ b/src/dataWriter.cpp
@@ -21,22 +21,24 @@ DataWriter::DataWriter(
     //delim = applicationSettings->value("delimiterToUse", ',').toChar(); // somehow this just doesnt work
 
     //delim = delimToUse; // only used if dataFormat=='P'
-    std::cout << "New DataWriter object created." << std::endl;
+    qDebug() << "New DataWriter object created.";
 
     // Header definitions of the output file, this must fit the output format in the pupilToRow functions
     header = EyeDataSerializer::getHeaderCSV(procMode, delim);
 
-    std::cout<<fileName.toStdString()<<std::endl;
+    qDebug() << fileName;
 
+    /*
     bool pathWriteable = SupportFunctions::preparePath(fileName); // GB added
     if(!pathWriteable) {
         QMessageBox MsgBox;
         MsgBox.setText("Recording failure. Could not create path.");
         MsgBox.exec();
     }
+    */
 
     dataFile = new QFile(fileName);
-    bool exists = dataFile->exists();
+    bool exists = dataFile->exists(); // NOTE: should never happen
 
     // Open the file in append mode
     // GB: needed to double check, in case of writing to e.g. C:/ or other admin-only folder, 
@@ -61,7 +63,8 @@ DataWriter::DataWriter(
     if(!exists)
         *textStream << header << Qt::endl;
 
-    if(!pathWriteable || !fileWriteable)
+    //if(!pathWriteable || !fileWriteable)
+    if(!fileWriteable)
         this->deleteLater();
 }
 

--- a/src/imageWriter.h
+++ b/src/imageWriter.h
@@ -6,6 +6,7 @@
     @author Moritz Lode, Gábor Bényei
 */
 
+#include <QCoreApplication>
 #include <QtCore/qdir.h>
 #include "devices/camera.h"
 
@@ -28,7 +29,7 @@ Q_OBJECT
 public:
 
     // Format: Bmp is fastest as it doesnt compress, jpg is also fast "enough" but results in higher cpu load
-    ImageWriter(const QString& directory, QString format="bmp", bool stereo=false, QObject *parent = 0);
+    ImageWriter(const QString& directory, bool stereo=false, QObject *parent = 0);
     ~ImageWriter() override;
 
     // GB added begin
@@ -44,8 +45,10 @@ public:
 
 private:
 
+    QSettings *applicationSettings;
     QDir outputDirectory, outputDirectorySecondary;
-    QString format;
+    QString imageWriterFormat;
+    QString imageWriterDataRule;
     bool stereoMode;
 
 public slots:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1028,18 +1028,18 @@ void MainWindow::onStreamClick() {
 
 void MainWindow::onRecordClick() {
 
-    // GB added begin
     if(pupilDetectionDataFile.isEmpty())
         return;
-    // GB added end
 
     if(recordOn && dataWriter) {
         // Deactivate recording
 
         dataWriter->close(); // TODO check if may terminate writing to early? because of the lag of the event queue in pupildetection
-        // GB added: this way we can safely check like if(var!=nullptr) or if(var)
+        // GB: this way we can safely check like if(var!=nullptr) or if(var)
         dataWriter = nullptr;
-        // GB added end
+
+        if(generalSettingsDialog)
+            generalSettingsDialog->setLimitationsWhileDataWriting(false);
 
         const QIcon recordOffIcon = SVGIconColorAdjuster::loadAndAdjustColors(QString(":/icons/Breeze/actions/22/media-record.svg"), applicationSettings); //QIcon::fromTheme("camera-video");
         recordAct->setIcon(recordOffIcon);
@@ -1048,7 +1048,12 @@ void MainWindow::onRecordClick() {
     } else {
         // Activate recording
 
-        // GB modified/added begin
+        if(generalSettingsDialog)
+            generalSettingsDialog->setLimitationsWhileDataWriting(true);
+
+        // TODO: this version is imperfect yet, as it permanently overwrites pupilDetectionDataFile name
+        pupilDetectionDataFile = SupportFunctions::prepareOutputFileForImageWriter(pupilDetectionDataFile, applicationSettings, this);
+
         dataWriter = 
             new DataWriter(
                 pupilDetectionDataFile, 
@@ -1073,7 +1078,6 @@ void MainWindow::onRecordClick() {
             MetaSnapshotOrganizer::writeMetaSnapshot(
                 pupilDetectionDir.filePath(metadataFileName),
                 selectedCamera, imageWriter, pupilDetectionWorker, dataWriter, applicationSettings);
-        // GB added end
         
         // GB new kind of signals
         connect(pupilDetectionWorker, SIGNAL (processedPupilData(quint64, int, std::vector<Pupil>, QString)), dataWriter, SLOT (newPupilData(quint64, int, std::vector<Pupil>, QString)));
@@ -1112,6 +1116,9 @@ void MainWindow::onRecordImageClick() {
             stereoCameraSettingsDialog->setLimitationsWhileTracking(false);
         if(singleWebcamSettingsDialog && !trackingOn)
             singleWebcamSettingsDialog->setLimitationsWhileTracking(false);
+
+        if(generalSettingsDialog)
+            generalSettingsDialog->setLimitationsWhileImageWriting(false);
         // GB added end
     } else {
         // Activate recording
@@ -1129,21 +1136,27 @@ void MainWindow::onRecordImageClick() {
             stereoCameraSettingsDialog->setLimitationsWhileTracking(true);
         if(singleWebcamSettingsDialog)
             singleWebcamSettingsDialog->setLimitationsWhileTracking(true);
-        
-        if( applicationSettings->value("metaSnapshotsEnabled", "1") == "1" || 
+
+        if(generalSettingsDialog)
+            generalSettingsDialog->setLimitationsWhileImageWriting(true);
+
+        bool stereo = selectedCamera->getType() == CameraImageType::LIVE_STEREO_CAMERA || selectedCamera->getType() == CameraImageType::STEREO_IMAGE_FILE;
+
+        // TODO: why use string everywhere for directory? Use QDir instead, or clarify naming ("directory" variables should all be QString or QDir type)
+        // TODO: this version is imperfect yet, as it permanently overwrites outputDirectory (image output directory) name
+        outputDirectory = SupportFunctions::prepareOutputDirForImageWriter(outputDirectory, applicationSettings, this);
+        imageWriter = new ImageWriter(outputDirectory, stereo, this);
+
+        // this should come here as the "directory already exists" dialog is only answered before, upon creation of imageWriter, and meta snapshot creation relies on that response
+        if( applicationSettings->value("metaSnapshotsEnabled", "1") == "1" ||
             applicationSettings->value("metaSnapshotsEnabled", "1") == "true" ) {
-            
+
             MetaSnapshotOrganizer::writeMetaSnapshot(
-                outputDirectory + "/" + QString::fromStdString("imagerec-meta.xml"),
-                selectedCamera, imageWriter, pupilDetectionWorker, dataWriter, applicationSettings);
+                    outputDirectory + "/" + QString::fromStdString("imagerec-meta.xml"),
+                    selectedCamera, imageWriter, pupilDetectionWorker, dataWriter, applicationSettings);
         }
         // GB: maybe write unix timestamp too in the name of meta snapshot file?
         // GB added end
-
-        const QString imageFormat = applicationSettings->value("writerFormat", generalSettingsDialog->getWriterFormat()).toString();
-
-        bool stereo = selectedCamera->getType() == CameraImageType::LIVE_STEREO_CAMERA || selectedCamera->getType() == CameraImageType::STEREO_IMAGE_FILE;
-        imageWriter = new ImageWriter(outputDirectory, imageFormat, stereo, this);
 
         // connect(selectedCamera, SIGNAL (onNewGrabResult(CameraImage)), signalPubSubHandler, SLOT (onNewImage(CameraImage)));
         connect(signalPubSubHandler, SIGNAL(onNewGrabResult(CameraImage)), imageWriter, SLOT (onNewImage(CameraImage)));
@@ -1888,7 +1901,7 @@ void MainWindow::openImageDirectory(QString imageDirectory) {
     imagePlaybackControlDialog = new ImagePlaybackControlDialog(dynamic_cast<FileCamera*>(selectedCamera), pupilDetectionWorker, recEventTracker, this);
     RestorableQMdiSubWindow *imagePlaybackControlWindow = new RestorableQMdiSubWindow(imagePlaybackControlDialog, "ImagePlaybackControlDialog", this);
     mdiArea->addSubWindow(imagePlaybackControlWindow);
-    imagePlaybackControlWindow->resize(650, 230);
+    //imagePlaybackControlWindow->resize(650, 230); // Min. size will set automatically anyways
     // No "X" button on this window
     imagePlaybackControlWindow->setWindowFlags(Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowMinMaxButtonsHint | Qt::WindowStaysOnTopHint);
     //imagePlaybackControlWindow->setWindowFlags(imagePlaybackControlWindow->windowFlags() & ~Qt::WindowCloseButtonHint);
@@ -2368,7 +2381,7 @@ void MainWindow::dropEvent(QDropEvent* e)
         openImageDirectory(fileInfo.filePath());
     } else if(fileInfo.isFile()) {
         // TODO: do this with a QMap that is stored in persistence/QSettings
-        if(fileInfo.completeSuffix() == "tiff" || fileInfo.completeSuffix() == "bmp" || fileInfo.completeSuffix() == "png" ||
+        if(fileInfo.completeSuffix() == "tiff" || fileInfo.completeSuffix() == "jpg" || fileInfo.completeSuffix() == "bmp" || fileInfo.completeSuffix() == "png" ||
             fileInfo.fileName() == "imagerec-meta.xml" || fileInfo.fileName() == "offline-event-log.xml") {
 
             if(selectedCamera && selectedCamera->isOpen()) {

--- a/src/subwindows/generalSettingsDialog.h
+++ b/src/subwindows/generalSettingsDialog.h
@@ -32,9 +32,11 @@ public:
     int getPlaybackSpeed() const;
     bool getPlaybackLoop() const;
 
-    QString getWriterFormat() const;
+    QString getImageWriterFormat() const;
+    QString getImageWriterDataRule() const;
 
     // GB added begin
+    QString getDataWriterDataRule() const;
     bool getMetaSnapshotsEnabled() const;
     bool getSaveOfflineEventLog() const; 
     // GB added end
@@ -43,12 +45,16 @@ private:
 
     QSettings *applicationSettings;
 
-    QString writerFormat;
+    QGroupBox *dataWriterGroup;
+    QGroupBox *imageWriterGroup;
+    QString imageWriterFormat;
+    QString imageWriterDataRule;
 
     QPushButton *applyButton;
     QPushButton *cancelButton;
 
-    QComboBox *formatBox;
+    QComboBox *imageWriterFormatBox;
+    QComboBox *imageWriterDataRuleBox;
     QSpinBox *playbackSpeedInputBox;
     QCheckBox *playbackLoopBox;
 
@@ -57,7 +63,9 @@ private:
     bool saveOfflineEventLog; 
 
     QString delimiterToUse;
+    QString dataWriterDataRule;
     QComboBox *delimiterBox;
+    QComboBox *dataWriterDataRuleBox;
 
     int darkAdaptMode;
     QComboBox *darkAdaptBox;
@@ -69,21 +77,30 @@ private:
     void saveSettings();
     void updateForm();
 
-private slots:
+public slots:
 
+    void open() override;
     void apply();
     void cancel();
-    void onFormatChange(int index);
+    void onImageWriterFormatChange(int index);
+    void onImageWriterDataRuleChange(int index);
     void readSettings();
     //void setPlaybackSpeed(int playbackSpeed);
-    void setWriterFormat(const QString &writerFormat);
+    void setImageWriterFormat(const QString &imageWriterFormat);
+    void setImageWriterDataRule(const QString &imageWriterDataRule);
+    void setDataWriterDataRule(const QString &dataWriterDataRule);
     //void setPlaybackLoop(int m_state);
 
     // GB added begin
-    void onDelimiterChange(int index); 
+    void onDelimiterChange(int index);
+    void onDataWriterDataRuleChange(int index);
     void onDarkAdaptChange(int index);
     void setMetaSnapshotEnabled(int m_state);
     void setSaveOfflineEventLog(int m_state);
+
+    void setLimitationsWhileImageWriting(bool state);
+    void setLimitationsWhileDataWriting(bool state);
+    void onSettingsChangedElsewhere();
     // GB added end
 
 signals:

--- a/src/subwindows/outputDataRuleDialog.cpp
+++ b/src/subwindows/outputDataRuleDialog.cpp
@@ -1,0 +1,59 @@
+//
+// Created by epresleves on 2024. 04. 17..
+//
+
+#include "outputDataRuleDialog.h"
+
+OutputDataRuleDialog::OutputDataRuleDialog(const QString windowTitle, QWidget *parent) :
+        QDialog(parent)
+{
+    this->setWindowTitle(windowTitle);
+    this->setMinimumSize(450,150);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+
+    QLabel *dialogLabel = new QLabel(tr("Existing data was found under the target path/name you specified. Please choose whether you would like to append to the existing recording or keep it and save the new recording with an automatically generated different path/name?"));
+    dialogLabel->setWordWrap(true);
+    mainLayout->addWidget(dialogLabel);
+
+    rememberChoiceBox = new QCheckBox(tr("Remember this choice"));
+    mainLayout->addWidget(rememberChoiceBox);
+
+    QFormLayout *buttonsLayout = new QFormLayout(this);
+    buttonAppend = new QPushButton(tr("Append to existing"));
+    buttonKeepAndSaveNew = new QPushButton(tr("Keep existing and save new as well"));
+    buttonAppend->setFixedWidth(210);
+    //buttonKeepAndSaveNew->setFixedWidth(200);
+    buttonsLayout->addRow(buttonAppend, buttonKeepAndSaveNew);
+    mainLayout->addLayout(buttonsLayout);
+
+    setLayout(mainLayout);
+
+    connect(buttonAppend, &QPushButton::clicked, this, &OutputDataRuleDialog::onAppendClicked);
+    connect(buttonKeepAndSaveNew, &QPushButton::clicked, this, &OutputDataRuleDialog::onKeepAndSaveNewClicked);
+
+}
+
+OutputDataRuleDialog::~OutputDataRuleDialog()  = default;
+
+OutputDataRuleDialog::OutputDataRuleResponse OutputDataRuleDialog::getResponse(){
+    return outputDataRuleResponse;
+}
+
+bool OutputDataRuleDialog::getRememberChoice(){
+    return rememberChoice;
+}
+
+void OutputDataRuleDialog::onAppendClicked()
+{
+    rememberChoice = rememberChoiceBox->isChecked();
+    outputDataRuleResponse = OutputDataRuleResponse::APPEND;
+    accept();
+}
+
+void OutputDataRuleDialog::onKeepAndSaveNewClicked()
+{
+    rememberChoice = rememberChoiceBox->isChecked();
+    outputDataRuleResponse = OutputDataRuleResponse::KEEP_AND_SAVE_NEW;
+    accept();
+}

--- a/src/subwindows/outputDataRuleDialog.h
+++ b/src/subwindows/outputDataRuleDialog.h
@@ -1,0 +1,40 @@
+//
+// Created by epresleves on 2024. 04. 17..
+//
+
+#ifndef PUPILEXT_OUTPUTDATARULEDIALOG_H
+#define PUPILEXT_OUTPUTDATARULEDIALOG_H
+
+#include <QtWidgets>
+#include <QDialog>
+#include <QCheckBox>
+#include <QDebug>
+#include <QLabel>
+#include <QVBoxLayout>
+
+class OutputDataRuleDialog : public QDialog {
+Q_OBJECT
+
+public:
+
+    enum OutputDataRuleResponse {APPEND = 1, KEEP_AND_SAVE_NEW = 2};
+
+
+    explicit OutputDataRuleDialog(const QString windowTitle, QWidget *parent = nullptr);
+    ~OutputDataRuleDialog() override;
+    OutputDataRuleResponse getResponse();
+    bool getRememberChoice();
+
+private slots:
+    void onAppendClicked();
+    void onKeepAndSaveNewClicked();
+
+private:
+    OutputDataRuleResponse outputDataRuleResponse;
+    bool rememberChoice = false;
+    QCheckBox *rememberChoiceBox;
+    QPushButton *buttonAppend;
+    QPushButton *buttonKeepAndSaveNew;
+};
+
+#endif //PUPILEXT_OUTPUTDATARULEDIALOG_H


### PR DESCRIPTION
In case an existing recording is found, the program should be able to handle cases to append or save-as-new, as user desires. Added feature as a pop up window which asks user to confirm, whether they want to keep the original recording (image or csv data recording) or let the program automatically assign a new name for the recordsing and save data using this new name, keeping existing data untouched. Automatically generated folder and csv names will end with "_Run*" siffix, where * is substututed by a number representing the number of the analysis run, as a unique identifier character array.