### PR TITLE
Solved issue #6 and committed several minor changes related to other issues

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1069,7 +1069,7 @@ void MainWindow::onRecordClick() {
         
         QFileInfo fi(pupilDetectionDataFile);
         QDir pupilDetectionDir = fi.dir();
-        QString metadataFileName = fi.baseName() + QString::fromStdString("-datarec-meta.xml");
+        QString metadataFileName = fi.baseName() + QString::fromStdString("_datarec_meta.xml");
 
         int currentProcMode = pupilDetectionWorker->getCurrentProcMode();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1077,7 +1077,7 @@ void MainWindow::onRecordClick() {
             applicationSettings->value("metaSnapshotsEnabled", "1") == "true" ))
             MetaSnapshotOrganizer::writeMetaSnapshot(
                 pupilDetectionDir.filePath(metadataFileName),
-                selectedCamera, imageWriter, pupilDetectionWorker, dataWriter, applicationSettings);
+                selectedCamera, imageWriter, pupilDetectionWorker, dataWriter, MetaSnapshotOrganizer::Purpose::DATA_REC, applicationSettings);
         
         // GB new kind of signals
         connect(pupilDetectionWorker, SIGNAL (processedPupilData(quint64, int, std::vector<Pupil>, QString)), dataWriter, SLOT (newPupilData(quint64, int, std::vector<Pupil>, QString)));
@@ -1106,8 +1106,8 @@ void MainWindow::onRecordImageClick() {
             recEventTracker->saveOfflineEventLog(
                 imageRecStartTimestamp,
                 std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(),
-                outputDirectory + "/" + QString::fromStdString("offline-event-log.xml") );
-                //outputDirectory + "/" + QString::fromStdString("offline-event-log.csv") );
+                outputDirectory + "/" + QString::fromStdString("offline_event_log.xml") );
+                //outputDirectory + "/" + QString::fromStdString("offline_event_log.csv") );
         }
         
         if(singleCameraSettingsDialog && !trackingOn)
@@ -1152,8 +1152,8 @@ void MainWindow::onRecordImageClick() {
             applicationSettings->value("metaSnapshotsEnabled", "1") == "true" ) {
 
             MetaSnapshotOrganizer::writeMetaSnapshot(
-                    outputDirectory + "/" + QString::fromStdString("imagerec-meta.xml"),
-                    selectedCamera, imageWriter, pupilDetectionWorker, dataWriter, applicationSettings);
+                    outputDirectory + "/" + QString::fromStdString("imagerec_meta.xml"),
+                    selectedCamera, imageWriter, pupilDetectionWorker, dataWriter, MetaSnapshotOrganizer::Purpose::IMAGE_REC, applicationSettings);
         }
         // GB: maybe write unix timestamp too in the name of meta snapshot file?
         // GB added end
@@ -1814,8 +1814,7 @@ void MainWindow::openImageDirectory(QString imageDirectory) {
     // create simulated FileCamera
 
     // GB added begin
-    //QString offlineEventLogFileName = imageDirectory + '/' + "offline-event-log.csv";
-    QString offlineEventLogFileName = imageDirectory + '/' + "offline-event-log.xml";
+    QString offlineEventLogFileName = imageDirectory + '/' + "offline_event_log.xml";
     std::cout << "expected offlineEventLogFileName = " << offlineEventLogFileName.toStdString() << std::endl;
     if(QFileInfo(offlineEventLogFileName).exists() == true) {
         recEventTracker = new RecEventTracker(offlineEventLogFileName);
@@ -2289,7 +2288,7 @@ void MainWindow::resetStatus(bool isConnect)
         //streamAct->setEnabled(true);
 
         outputDirectoryAct->setEnabled(imageRecordingEnabled);
-        recordImagesAct->setEnabled(imageRecordingEnabled);
+        recordImagesAct->setEnabled(imageRecordingEnabled && !outputDirectory.isEmpty());
         forceResetTrialAct->setEnabled(imageRecordingEnabled);
         manualIncTrialAct->setEnabled(imageRecordingEnabled);
 
@@ -2306,10 +2305,10 @@ void MainWindow::resetStatus(bool isConnect)
         logFileAct->setEnabled(false);
         //streamAct->setEnabled(false);
 
-        outputDirectoryAct->setEnabled(imageRecordingEnabled);
-        recordImagesAct->setEnabled(imageRecordingEnabled);
-        forceResetTrialAct->setEnabled(imageRecordingEnabled);
-        manualIncTrialAct->setEnabled(imageRecordingEnabled);
+        outputDirectoryAct->setEnabled(false);
+        recordImagesAct->setEnabled(false);
+        forceResetTrialAct->setEnabled(false);
+        manualIncTrialAct->setEnabled(false);
 
         streamingSettingsAct->setEnabled(false);
         trialWidget->setVisible(false);
@@ -2397,7 +2396,8 @@ void MainWindow::dropEvent(QDropEvent* e)
     } else if(fileInfo.isFile()) {
         // TODO: do this with a QMap that is stored in persistence/QSettings
         if(fileInfo.completeSuffix() == "tiff" || fileInfo.completeSuffix() == "jpg" || fileInfo.completeSuffix() == "bmp" || fileInfo.completeSuffix() == "png" ||
-            fileInfo.fileName() == "imagerec-meta.xml" || fileInfo.fileName() == "offline-event-log.xml") {
+            fileInfo.fileName() == "imagerec_meta.xml" || fileInfo.fileName() == "offline_event_log.xml" ||
+            fileInfo.fileName() == "imagerec-meta.xml" || fileInfo.fileName() == "offline-event-log.xml" ) {
 
             if(selectedCamera && selectedCamera->isOpen()) {
                 onCameraDisconnectClick();

--- a/src/metaSnapshotOrganizer.cpp
+++ b/src/metaSnapshotOrganizer.cpp
@@ -7,14 +7,14 @@
 // added by kheki4 on 2022.11.07.
 
 
-void MetaSnapshotOrganizer::writeMetaSnapshot(QString fileName, Camera *camera, ImageWriter *imageWriter, PupilDetection *pupilDetection, DataWriter *dataWriter, QSettings *applicationSettings) {
+void MetaSnapshotOrganizer::writeMetaSnapshot(QString fileName, Camera *camera, ImageWriter *imageWriter, PupilDetection *pupilDetection, DataWriter *dataWriter, Purpose purpose, QSettings *applicationSettings) {
 
     qDebug() << fileName;
     QDomDocument document;
     QDomElement root = document.createElement("MetaSnapshot");
     document.appendChild(root);
 
-    addInfoNode(document, root, imageWriter, dataWriter, fileName);    
+    addInfoNode(document, root, imageWriter, dataWriter, purpose, fileName);
 
     addCameraNode(document, root, camera);
 
@@ -24,9 +24,12 @@ void MetaSnapshotOrganizer::writeMetaSnapshot(QString fileName, Camera *camera, 
     QString payload = document.toString();
 
 
+    bool changedGiven = false;
+    QString changedPath;
+    bool pathWriteable = SupportFunctions::preparePath(fileName, changedGiven, changedPath);
+    //if(changedGiven)
+    //    QMessageBox::warning(nullptr, "Path name changed", "The given path/name contained nonstandard characters,\nwhich were changed automatically for the following: a-z, A-Z, 0-9, _");
 
-    // write to file
-    SupportFunctions::preparePath(fileName);
     QFile* dataFile = new QFile(fileName);
     //if(dataFile->exists() == false) {
     //    return;
@@ -55,10 +58,15 @@ void MetaSnapshotOrganizer::writeMetaSnapshot(QString fileName, Camera *camera, 
     
 }
 
-void MetaSnapshotOrganizer::addInfoNode(QDomDocument &document, QDomElement &root, ImageWriter *imageWriter, DataWriter *dataWriter, QString fileName) {
+void MetaSnapshotOrganizer::addInfoNode(QDomDocument &document, QDomElement &root, ImageWriter *imageWriter, DataWriter *dataWriter, Purpose purpose, QString fileName) {
     
     QMap<QString, QString> metaSnapshot;
     metaSnapshot["version"] = QString::number(version);
+    if(purpose==DATA_REC) {
+        metaSnapshot["purpose"] = "datarec";
+    } else if(purpose==IMAGE_REC) {
+        metaSnapshot["purpose"] = "imagerec";
+    }
     metaSnapshot["creationTime"] = QDateTime::currentDateTime().toString("yyyy. MMM dd. hh:mm:ss");
     metaSnapshot["name"] = QString(fileName);
     metaSnapshot["creationTimeUnix"] = QString::number(QDateTime::currentMSecsSinceEpoch());

--- a/src/metaSnapshotOrganizer.h
+++ b/src/metaSnapshotOrganizer.h
@@ -30,11 +30,13 @@ class MetaSnapshotOrganizer : public QObject {
 
 public:
 
-    static void addInfoNode(QDomDocument &document, QDomElement &root, ImageWriter *imageWriter, DataWriter *dataWriter, QString fileName);
+    enum Purpose {IMAGE_REC = 1, DATA_REC = 2};
+
+    static void addInfoNode(QDomDocument &document, QDomElement &root, ImageWriter *imageWriter, DataWriter *dataWriter, Purpose purpose, QString fileName);
     static void addCameraNode(QDomDocument &document, QDomElement &root, Camera *camera);
     static void addPupilDetectionNode(QDomDocument &document, QDomElement &root, PupilDetection *pupilDetection, QSettings *applicationSettings);
     
-    static void writeMetaSnapshot(QString fileName, Camera *camera, ImageWriter *imageWriter, PupilDetection *pupilDetection, DataWriter *dataWriter, QSettings *applicationSettings);
+    static void writeMetaSnapshot(QString fileName, Camera *camera, ImageWriter *imageWriter, PupilDetection *pupilDetection, DataWriter *dataWriter, Purpose purpose, QSettings *applicationSettings);
 
     static void addMapToNode(QDomDocument &document, QMap<QString, QString> map, QDomElement &parent);
 };

--- a/src/recEventTracker.cpp
+++ b/src/recEventTracker.cpp
@@ -228,7 +228,14 @@ void RecEventTracker::close()
 void RecEventTracker::saveOfflineEventLog(uint64 timestampFrom, uint64 timestampTo, const QString &fileName) {
 
     std::cout << fileName.toStdString() << std::endl;
-    SupportFunctions::preparePath(fileName);
+
+    bool changedGiven = false;
+    QString changedPath;
+    bool pathWriteable = SupportFunctions::preparePath(fileName, changedGiven, changedPath);
+    //if(changedGiven)
+    //    QMessageBox::warning(nullptr, "Path name changed", "The given path/name contained nonstandard characters,\nwhich were changed automatically for the following: a-z, A-Z, 0-9, _");
+
+
     QByteArray textContent;
 
     dataFile = new QFile(fileName);

--- a/src/recEventTracker.h
+++ b/src/recEventTracker.h
@@ -46,9 +46,9 @@ struct Message {
         2, In case of an opened camera input device (BUFFER mode): 
             it represents temporary buffer to store frame-related info in, without slowing image processing 
             via adding extra data fields to some or each CameraImage instance that is passed down the pupil detection chain.
-            Also it can save event vectors into an offline-event-log.csv
+            Also it can save event vectors into an offline_event_log.csv
         3, When an image directory is opened for reading (STORAGE mode):
-            Tries to open an offline-event-log.csv containing trial increment events, etc.
+            Tries to open an offline_event_log.csv containing trial increment events, etc.
     
 */
 class RecEventTracker : public QObject {

--- a/src/subwindows/remoteCCDialog.cpp
+++ b/src/subwindows/remoteCCDialog.cpp
@@ -51,7 +51,7 @@ void RemoteCCDialog::createForm() {
     //udpIpBox->setFixedWidth(140);
 
     //udpIpBox->text();
-    udpIpBox->setValue("192.168.0.1");
+    udpIpBox->setValue("0.0.0.0");
 
     udpLayout->addRow(udpIpLabel, udpIpBox);
 
@@ -415,7 +415,7 @@ void RemoteCCDialog::interpretCommand(const QString &msg, const quint64 &timesta
 
     MainWindow *w = dynamic_cast<MainWindow*>(mainWindow);
 
-    //qDebug() << "Message is the following: \n" << msg;
+    qDebug() << "Message is the following: \n" << msg;
 
     if(msg.isEmpty()) {
         qDebug() << "Received an empty datagram for a remote control command. No action performed.";

--- a/src/subwindows/singleCameraCalibrationView.cpp
+++ b/src/subwindows/singleCameraCalibrationView.cpp
@@ -246,7 +246,7 @@ void SingleCameraCalibrationView::closeEvent(QCloseEvent *event) {
 
     if(calibrationWorker->isCalibrated()) {
         QString configFile = camera->getCalibrationFilename();
-        configFile.replace(" ", "");
+        //configFile.replace(" ", ""); // Commented out by BG on 2024.04.22., refer to https://github.com/openPupil/Open-PupilEXT/issues/42
         std::cout<<"Saving calibration file to settings directory: "<< configFile.toStdString() <<std::endl;
         calibrationWorker->saveToFile(configFile.toStdString().c_str());
         QWidget::closeEvent(event);
@@ -295,7 +295,7 @@ void SingleCameraCalibrationView::updateSettings() {
 // File is in the OpenCV XML filestorage fileformat
 void SingleCameraCalibrationView::loadConfigFile() {
     QString configFile = camera->getCalibrationFilename();
-    configFile.replace(" ", "");
+    //configFile.replace(" ", ""); // Commented out by BG on 2024.04.22., refer to https://github.com/openPupil/Open-PupilEXT/issues/42
     if (QFile::exists(configFile)) {
         std::cout << "Found calibration file in settings directory. Loading: " << configFile.toStdString()
                   << std::endl;

--- a/src/subwindows/singleWebcamCalibrationView.cpp
+++ b/src/subwindows/singleWebcamCalibrationView.cpp
@@ -239,7 +239,7 @@ void SingleWebcamCalibrationView::closeEvent(QCloseEvent *event) {
 
     if(calibrationWorker->isCalibrated()) {
         QString configFile = camera->getCalibrationFilename();
-        configFile.replace(" ", "");
+        //configFile.replace(" ", ""); // Commented out by BG on 2024.04.22., refer to https://github.com/openPupil/Open-PupilEXT/issues/42
         std::cout<<"Saving calibration file to settings directory: "<< configFile.toStdString() <<std::endl;
         calibrationWorker->saveToFile(configFile.toStdString().c_str());
         QWidget::closeEvent(event);
@@ -288,7 +288,7 @@ void SingleWebcamCalibrationView::updateSettings() {
 // File is in the OpenCV XML filestorage fileformat
 void SingleWebcamCalibrationView::loadConfigFile() {
     QString configFile = camera->getCalibrationFilename();
-    configFile.replace(" ", "");
+    //configFile.replace(" ", ""); // Commented out by BG on 2024.04.22., refer to https://github.com/openPupil/Open-PupilEXT/issues/42
     if (QFile::exists(configFile)) {
         std::cout << "Found calibration file in settings directory. Loading: " << configFile.toStdString()
                   << std::endl;

--- a/src/subwindows/stereoCameraCalibrationView.cpp
+++ b/src/subwindows/stereoCameraCalibrationView.cpp
@@ -229,7 +229,7 @@ void StereoCameraCalibrationView::onSaveClick() {
     QString filename = QFileDialog::getSaveFileName(this, tr("Save Calibration File"), "", tr("XML files (*.xml)"));
 
     if(!filename.isEmpty()) {
-        filename.replace(" ", "");
+        // filename.replace(" ", ""); // Commented out by BG on 2024.04.22., refer to https://github.com/openPupil/Open-PupilEXT/issues/42
 
         QFileInfo fileInfo(filename);
         // check if filename has extension, else append xml to it
@@ -258,7 +258,7 @@ void StereoCameraCalibrationView::closeEvent(QCloseEvent *event) {
 
     if(calibrationWorker->isCalibrated()) {
         QString configFile = camera->getCalibrationFilename();
-        configFile.replace(" ", "");
+        //configFile.replace(" ", ""); // Commented out by BG on 2024.04.22., refer to https://github.com/openPupil/Open-PupilEXT/issues/42
         std::cout<<"Saving calibration file to settings directory: "<< configFile.toStdString() <<std::endl;
         calibrationWorker->saveToFile(configFile.toStdString().c_str());
         QWidget::closeEvent(event);
@@ -288,7 +288,7 @@ void StereoCameraCalibrationView::onSharpnessThresholdBoxChange() {
 // Calibration filename is predefined by the configured calibration settings (pattern size etc.)
 void StereoCameraCalibrationView::loadConfigFile() {
     QString configFile = camera->getCalibrationFilename();
-    configFile.replace(" ", "");
+    //configFile.replace(" ", ""); // Commented out by BG on 2024.04.22., refer to https://github.com/openPupil/Open-PupilEXT/issues/42
     if (QFile::exists(configFile)) {
         std::cout << "Found calibration file in settings directory. Loading: " << configFile.toStdString()
                   << std::endl;

--- a/src/subwindows/streamingSettingsDialog.cpp
+++ b/src/subwindows/streamingSettingsDialog.cpp
@@ -41,7 +41,7 @@ void StreamingSettingsDialog::createForm() {
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
 
-    QString udpIp = "192.168.0.1";
+    QString udpIp = "127.0.0.1";
     int udpPort = 6900;
 
 

--- a/src/supportFunctions.h
+++ b/src/supportFunctions.h
@@ -54,7 +54,7 @@ public:
         // Qt has this method to remove trailing whitespace from the beginning and the end of a string, and replace internal whitespaces with a single space
         str = str.simplified();
         // if there are "\" characters, change them to "/"
-        str.replace("\\", "/");
+        str.replace("\\", "/"); // TODO: WARNING: can interfere with OS-native separator, though / is safe but \ is not always so
         // todo: remove "..." and replace with ".." as long as they persist, etc. Now it is just a workaround
         str.replace("/./", "/");
         str.replace("...", "..");
@@ -62,7 +62,24 @@ public:
         return str;
     };
 
-    static bool preparePath(const QString &target)
+    // This function is used to simplify directory names that are auto-created (not selected in a GUI dialog by the user)
+    // Only a-z, 0-9, and _ are accepted, anything else will translate to _ character, and length will be trimmed to 240 chars
+    // (usually 255 is max by filesystems, but we reserve the last chars for auto-naming in worst-case scenarios)
+    static QString simplifyNewPathNodeName(QString str, bool &changed)
+    {
+        QString str2 = str;
+        // [^a-zA-Z\d\s:]
+        // [^a-zA-Z0-9_:]
+        // [-`~!@#$%^&*()—+=|:;<>«»,.?/{}'"\[\]\]
+        str2.replace(QRegExp(QString::fromUtf8("[^a-zA-Z0-9_:]")), "_");
+        str2 = str2.mid(0, qMin(str.size(), 240));
+        if(str2!=str) {
+            changed = true;
+        }
+        return str2;
+    };
+
+    static bool preparePath(const QString &target, bool &changedAnything, QString &changedPath)
     {
 
         if (QFileInfo(target).absoluteDir().exists() == true)
@@ -93,24 +110,47 @@ public:
         }
         // std::cout << "desiredPath = " << desiredPath.toStdString() << std::endl;
         QStringList subStrings = desiredPath.split('/');
-        bool success = false;
+        bool candidateExists = false;
+        bool changedExists = false;
+        bool newNodeCreated = false;
+        bool changedNodeName = false;
 
         // std::cout << "subStrings 0-th elem = " << subStrings[0].toStdString() << std::endl;
         QString cumulatedPath = subStrings[0] + "/";
-        for (int h = 1; h < subStrings.length(); h++)
+        QString cumulatedPathCandidate;
+        QString newNodeName;
+        for (int h = 1; h < subStrings.length() && !subStrings[h].isEmpty(); h++)
         {
             // std::cout << "subStrings n-th elem = " << subStrings[h].toStdString() << std::endl;
-            cumulatedPath = cumulatedPath + subStrings[h] + "/";
+            cumulatedPathCandidate = cumulatedPath + subStrings[h] + "/";
             // std::cout << "Now creating: " << QFileInfo(cumulatedPath).absolutePath().toStdString() << std::endl;
-            if (QFileInfo(cumulatedPath).absoluteDir().exists() == false)
+            candidateExists = QFileInfo(cumulatedPathCandidate).absoluteDir().exists();
+
+            if (!candidateExists)
             {
-                success = QDir().mkdir(QFileInfo(cumulatedPath).absolutePath());
-                if (!success)
+                // TODO: make some feedback, notify higher level code, and the user about the auto-renaming of illegal path/directory tree node names
+                newNodeName = simplifyNewPathNodeName(subStrings[h], changedNodeName);
+                cumulatedPath = cumulatedPath + newNodeName + "/";
+
+                newNodeCreated = QDir().mkdir(QFileInfo(cumulatedPath).absolutePath());
+                changedExists = QFileInfo(cumulatedPath).absoluteDir().exists();
+                if (!newNodeCreated && !changedExists)
                     break;
+
+                if(changedNodeName) {
+                    changedAnything = true;
+                    qDebug() << "Had to change directory name from: " << subStrings[h] << " to: " << newNodeName;
+                    changedNodeName = false;
+                }
+            } else {
+                cumulatedPath = cumulatedPathCandidate;
             }
         }
 
-        if (success)
+        if(changedAnything)
+            changedPath = cumulatedPath;
+
+        if (newNodeCreated)
             return true;
         else
             return false;
@@ -133,7 +173,14 @@ public:
     static QString prepareOutputDirForImageWriter(QString directory, QSettings* applicationSettings, QWidget* parent) {
         QString imageWriterDataRule = applicationSettings->value("imageWriterDataRule", "ask").toString();
 
-        SupportFunctions::preparePath(directory);
+        bool changedGiven = false;
+        QString changedPath;
+        bool pathWriteable = SupportFunctions::preparePath(directory, changedGiven, changedPath);
+        if(changedGiven) {
+            QMessageBox::warning(parent, "Path name changed",
+                                 "The given path/name contained nonstandard characters,\nwhich were changed automatically for the following: a-z, A-Z, 0-9, _");
+            directory = changedPath;
+        }
 
         QDir outputDirectory = QDir(directory);
         bool exists = outputDirectory.exists();
@@ -184,8 +231,15 @@ public:
     static QString prepareOutputFileForDataWriter(QString fileName, QSettings* applicationSettings, QWidget* parent) {
         QString dataWriterDataRule = applicationSettings->value("dataWriterDataRule", "ask").toString();
 
-        bool pathWriteable = SupportFunctions::preparePath(fileName); // GB added
+        bool changedGiven = false;
+        QString changedPath;
         // TODO: false case and exception handling
+        bool pathWriteable = SupportFunctions::preparePath(fileName, changedGiven, changedPath);
+        if(changedGiven) {
+            QMessageBox::warning(parent, "Path name changed",
+                                 "The given path/name contained nonstandard characters,\nwhich were changed automatically for the following: a-z, A-Z, 0-9, _");
+            fileName = changedPath;
+        }
 
         QFileInfo dataFile(fileName);
         bool exists = dataFile.exists();


### PR DESCRIPTION
Solved issue #6. 
And also:
- Implemented auto renaming of to-be-created folders when the output path is generated automatically for image and data recordings, instructed via remote control commands. Added user warning for auto name changes. 
- Changed defult 192.168.0.1 listen-IP filter address for UDP remote control connections to 0.0.0.0 and the broadcast target to 127.0.0.1 (these are on the GUI, but can be written to QSettings upon first opening of the program.)
- Fixed start image recording button that was enabled by mistake upon opening of a camera in spite of no directory set. 
- Commented out calls that remove whitespace from camera config file names. See issue #42 on Main branch or #108 on Experimental-Community-Version branch. 
- Changed dash (-) characters for better compatibility in naming of meta snapshots and event logs. Reading theese xml's is backward compatible with the dash version, but new files will be generated by the new underscore (_) as separator character. This is necessary for ease of use, as in specific langiages the dash character is denoted by different key codes, making it hard to search or rename by the user.